### PR TITLE
Listen only on localhost

### DIFF
--- a/cmd/gonvim/gonvim.go
+++ b/cmd/gonvim/gonvim.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	go func() {
-		http.ListenAndServe("0.0.0.0:6080", nil)
+		http.ListenAndServe("localhost:6080", nil)
 	}()
 	err := ui.Main(func() {
 		gonvim.InitEditor()


### PR DESCRIPTION
Both more secure and fixes firewall warning in OSX on startup. Couldn't think of a reason why you'd need to access this remotely so I didn't make it configurable.