### PR TITLE
Fix panic where lineheight is an int

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -354,8 +354,19 @@ func (e *Editor) guiFont(args ...interface{}) {
 
 func (e *Editor) guiLinespace(args ...interface{}) {
 	fontArg := args[0].([]interface{})
-	lineSpace, err := strconv.Atoi(fontArg[0].(string))
-	if err != nil {
+	var lineSpace int
+	var err error
+	switch arg := fontArg[0].(type) {
+	case string:
+		lineSpace, err = strconv.Atoi(arg)
+		if err != nil {
+			return
+		}
+	case int32: // can't combine these in a type switch without compile error
+		lineSpace = int(arg)
+	case int64:
+		lineSpace = int(arg)
+	default:
 		return
 	}
 	e.font.changeLineSpace(lineSpace)


### PR DESCRIPTION
If a user sets:

```
call GuiLinespace(2)
```

in their ginit.vim it triggers a panic

```
$ gonvim gonvim.go
Unhandle event mode_info_set
panic: interface conversion: interface {} is int64, not string

goroutine 24 [running]:
github.com/dzhou121/gonvim.(*Editor).guiLinespace(0xc42019a000, 0xc420029f40, 0x1, 0x1)
	/Users/pkates/Source/gocode/src/github.com/dzhou121/gonvim/editor.go:357 +0x128
github.com/dzhou121/gonvim.(*Editor).handleRPCGui(0xc42019a000, 0xc4201d1840, 0x2, 0x2)
	/Users/pkates/Source/gocode/src/github.com/dzhou121/gonvim/editor.go:227 +0x307
created by github.com/dzhou121/gonvim.(*Editor).handleNotification.func1
	/Users/pkates/Source/gocode/src/github.com/dzhou121/gonvim/editor.go:212 +0x5c
```

I kind of want to log an error on that default case but I couldn't really think of what would be an obvious mistake a user would make and I couldn't figure out how to log an error 😁 