### PR TITLE
Use git 'plumbing' command to avoid with color codes. (Fixes #26)

### DIFF
--- a/statusline.go
+++ b/statusline.go
@@ -265,7 +265,8 @@ func (s *StatuslineGit) Redraw(force bool) (int, int) {
 
 	s.file = file
 	dir := filepath.Dir(file)
-	out, err := exec.Command("git", "-C", dir, "branch").Output()
+	// prints branch name or "HEAD" if we are in a detached state.
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--symbolic-full-name", "--abbrev-ref", "HEAD").Output()
 	if err != nil {
 		if s.branch == "" {
 			return 0, 0
@@ -276,16 +277,7 @@ func (s *StatuslineGit) Redraw(force bool) (int, int) {
 		return 0, 0
 	}
 
-	branch := ""
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.HasPrefix(line, "* ") {
-			if strings.HasPrefix(line, "* (HEAD detached at ") {
-				branch = line[20 : len(line)-1]
-			} else {
-				branch = line[2:]
-			}
-		}
-	}
+	branch := strings.TrimSpace(string(out))
 	_, err = exec.Command("git", "-C", dir, "diff", "--quiet").Output()
 	if err != nil {
 		branch += "*"


### PR DESCRIPTION
This fixes the issue with the color codes it color.ui=always is set.

There would be a arguably bettter option [here recommended by a git maintainer](https://git-blame.blogspot.ch/2013/06/checking-current-branch-programatically.html) although that is git > 1.8

The solution here works with older versions of git and should not lead to compatibility issues.

Currently the displayed name in a detached state is HEAD. Is this ok or would you then prefer the commit hash?