### PR TITLE
Fix/tabline and fullscreen

### DIFF
--- a/editor/tabline.go
+++ b/editor/tabline.go
@@ -44,6 +44,11 @@ type Tab struct {
 func (t *Tabline) subscribe() {
 	if !t.ws.drawTabline {
 		t.widget.Hide()
+		t.height = 0
+		t.marginDefault = 0
+		t.marginTop = 0
+		t.marginBottom = 0
+		t.ws.updateSize()
 		return
 	}
 }

--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -405,10 +405,10 @@ func (w *Workspace) updateSize() {
 		}
 	}
 
-	if w.tabline.height == 0 {
+	if w.drawTabline && w.tabline.height == 0 {
 		w.tabline.height = w.tabline.widget.Height() - w.tabline.marginTop - w.tabline.marginBottom
 	}
-	if w.statusline.height == 0 {
+	if w.drawStatusline && w.statusline.height == 0 {
 		w.statusline.height = w.statusline.widget.Height()
 	}
 

--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -279,11 +279,11 @@ func (w *Workspace) configure() {
 		w.drawLint = true
 	}
 
-	// 	var startFullscreen interface{}
-	// 	w.nvim.Var("gonvim_start_fullscreen", &startFullscreen)
-	// 	if isTrue(startFullscreen) {
-	// 		e.window.ShowFullScreen()
-	// 	}
+	var startFullscreen interface{}
+	w.nvim.Var("gonvim_start_fullscreen", &startFullscreen)
+	if isTrue(startFullscreen) {
+		editor.window.ShowFullScreen()
+	}
 }
 
 func (w *Workspace) attachUI(path string) error {


### PR DESCRIPTION
I assume the commented out fullscreen is leftover from the workspace feature, so i fixed it.
For the tabline, when i initially added option to hide it, it didn't properly recalculate the height of the editor (now workspace), so we had a lot of space below the command line because of it. This fixes it.